### PR TITLE
Support paths with spaces in the username

### DIFF
--- a/conf/pharBat.template
+++ b/conf/pharBat.template
@@ -1,2 +1,2 @@
 @echo off
-php ##PHAR_FILENAME## %*
+php "##PHAR_FILENAME##" %*


### PR DESCRIPTION
Set the path to the phar file in quotes, to support paths where the username has spaces.